### PR TITLE
Hyprland 0.53.x window rule changes

### DIFF
--- a/hdrop
+++ b/hdrop
@@ -285,7 +285,10 @@ if $FLOATING; then
     ;;
   esac
 
-  if [[ $(hyprctl -j version | jq -r .version | tr '.' '\n' | head -n 2 | tail -n 1) -ge 48 ]]; then
+  if [[ $(hyprctl -j version | jq -r .version | tr '.' '\n' | head -n 2 | tail -n 1) -ge 53 ]]; then
+    hyprctl --batch "keyword windowrule match:class ^$CLASS$, float on; keyword windowrule match:class ^$CLASS$, move $POSITION_xy"
+    #hyprctl --batch "keyword windowrule match:class ^$CLASS$, float on, move $POSITION_xy"
+  elif [[ $(hyprctl -j version | jq -r .version | tr '.' '\n' | head -n 2 | tail -n 1) -ge 48 ]]; then
     hyprctl --batch "keyword windowrule float,class:^$CLASS$ ; keyword windowrule move $POSITION_xy,class:^$CLASS$"
   else
     hyprctl --batch "keyword windowrule float,^$CLASS$ ; keyword windowrule move $POSITION_xy,^$CLASS$"

--- a/hdrop
+++ b/hdrop
@@ -286,8 +286,12 @@ if $FLOATING; then
   esac
 
   if [[ $(hyprctl -j version | jq -r .version | tr '.' '\n' | head -n 2 | tail -n 1) -ge 53 ]]; then
-    hyprctl --batch "keyword windowrule match:class ^$CLASS$, float on; keyword windowrule match:class ^$CLASS$, move $POSITION_xy"
-    #hyprctl --batch "keyword windowrule match:class ^$CLASS$, float on, move $POSITION_xy"
+    # Not sure, why, but % is not working here
+    # TODO: Maybe check $POSITION to disable % there
+    if [[ $POSITION_xy =~ "0%" ]]; then
+      POSITION_xy="${POSITION_xy//%/}"
+    fi
+    hyprctl --batch "keyword windowrule match:class ^${CLASS}$, float on, move ${POSITION_xy}"
   elif [[ $(hyprctl -j version | jq -r .version | tr '.' '\n' | head -n 2 | tail -n 1) -ge 48 ]]; then
     hyprctl --batch "keyword windowrule float,class:^$CLASS$ ; keyword windowrule move $POSITION_xy,class:^$CLASS$"
   else


### PR DESCRIPTION
Hello,

I had just upgraded to Hyprland 0.53.x and the hdrop stopped to work. I added the new rule for version 0.53.x and found out, that there is a problem with move command 0% is not translated in my setup, so I have added replacement of % with nothing. I dont know all the things I could have broken, please feel free to change my code if needed.

Thanks,
Regards,
Petr Sourek